### PR TITLE
Disabled Travis build for feature branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  
+branches:
+  only:
+    - master
+    - /\d+\.\d+/
 
 before_script:
   - composer self-update && composer install --dev --prefer-source --no-interaction


### PR DESCRIPTION
Given that all feature branches have a PR which gets build by Travis, it is useless to build the branches as well.
